### PR TITLE
Adds Markdown content support.

### DIFF
--- a/lib/wp2ghost.js
+++ b/lib/wp2ghost.js
@@ -31,6 +31,7 @@ var slugify = function(title) {
 exports.fromStream = function(stream) {
   var Promise = require('promise');
   var XmlStream = require('xml-stream');
+  var markdown = require('html-md');
 
   return new Promise(function(resolve, reject) {
 
@@ -122,7 +123,7 @@ exports.fromStream = function(stream) {
         "id": parseInt(item['wp:post_id'], 10),
         "title": item.title,
         "slug": item['wp:post_name'],
-        "markdown": treat(item['content:encoded']),
+        "markdown": markdown(treatHTML(item['content:encoded'])),
         "html": treatHTML(item['content:encoded']),
         "image": null,
         "featured": item['wp:is_sticky'] === "1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   ],
   "dependencies": {
     "xml-stream": "0.4.x",
-    "promise": "^4.0.0"
+    "promise": "^4.0.0",
+    "html-md": "3.0.x"
   },
   "engine": "node >= 0.10",
   "devDependencies": {


### PR DESCRIPTION
This changeset adds support for saving a Markdown representation of the exported blog post content.
