### PR TITLE
Adding primative support for shortcode conversion

### DIFF
--- a/lib/wp2ghost.js
+++ b/lib/wp2ghost.js
@@ -3,6 +3,9 @@ var treat = function(html) {
   html = html.replace(/\r\n/g, "\n");
   html = html.replace(/\r/g, "\n");
   html = html.replace(/\[((source)?code)[^\]]*\]\n*([\s\S]*?)\n*\[\/\1\]/g, '<pre><code>$3</code></pre>');
+  html = html.replace(/\[caption.+\](.+)\[\/caption\]/g, '$1');
+  html = html.replace(/\[audio\s(.+)\]/g, reformatAudioShortcode);
+  html = html.replace(/\[video\s(.+)\]/g, reformatVideoShortcode);
   return html;
 }
 
@@ -12,6 +15,18 @@ var treatHTML = function(html) {
   html = html.replace(/<pre>(.*?)<\/pre>/g, function(match) { return match.replace(/<p>/g, "\n\n"); });
   html = html.replace(/<p><pre>/g, "<pre>");
   return html;
+}
+
+var reformatAudioShortcode = function(html){ 
+  var sources = html.match(/["'](.+?)["']/g).map(function(source) { return '<source src=' + source + '>'}).join('');
+  return '<audio controls>' + sources + '</audio>';
+}
+
+var reformatVideoShortcode = function(html) {
+  var sources = html.match(/"(.+?)"/g).map(function(source) { 
+    return '<source src='+ source +' type="video/' + source.match(/['"](.*)\.([^.]*)['"]$/)[2] + '">'
+  }).join('');
+  return '<video controls>' + sources + '</video>'
 }
 
 // From ghost/core/server/models/base.js

--- a/test/post.js
+++ b/test/post.js
@@ -84,4 +84,27 @@ describe('Post', function(){
       p.page.should.equal(0);
     });
   });
+
+  describe('shortcodes', function(){
+    it('should replace caption shortcodes', function() {
+      p.markdown.search('<a href="#"><img class="wp-image-1" alt="Sample Image" src="foo.jpg" width="150" height="150" /></a> FooBar Caption')
+                .should.not.equal(-1);
+    });
+    it('should replace audio shortcodes for a single source', function(){
+      p.markdown.search('<audio controls><source src="source.mp3"></audio>')
+                .should.not.equal(-1);
+    });
+    it('should replace audio shortcodes for a multiple sources', function(){
+      p.markdown.search('<audio controls><source src="source.ogg"><source src="source.wav"><source src="source.mp3"></audio>')
+                .should.not.equal(-1);
+    });
+    it('should replace video shortcodes for a single source', function(){
+      p.markdown.search('<video controls><source src="source.mp4" type="video/mp4"></video>')
+                .should.not.equal(-1);
+    });
+    it('should replace video shortcodes for multiple sources', function(){
+      p.markdown.search('<video controls><source src="source.mp4" type="video/mp4"><source src="source.ogv" type="video/ogv"></video>')
+                .should.not.equal(-1);
+    });
+  });
 });

--- a/test/wordpress-export.xml
+++ b/test/wordpress-export.xml
@@ -71,7 +71,22 @@
 
         Proin cursus, libero non auctor faucibus, urna mi vestibulum orci, sit amet fermentum nibh purus eget enim. Aenean aliquet ligula nec nulla. Praesent sit amet lorem vitae massa hendrerit auctor. Sed sit amet urna. Aenean sapien nunc, imperdiet a, pharetra in, consequat eu, neque. Phasellus vel sem gravida augue consequat tempor. Curabitur eget mauris at pede varius facilisis.
 
-        Morbi ut sapien. Morbi arcu mauris, suscipit congue, placerat sit amet, suscipit a, ante. Donec aliquet dui ac nunc. Mauris magna quam, aliquet quis, viverra eu, fringilla eget, purus. Donec tristique pretium sem.]]></content:encoded>
+        Morbi ut sapien. Morbi arcu mauris, suscipit congue, placerat sit amet, suscipit a, ante. Donec aliquet dui ac nunc. Mauris magna quam, aliquet quis, viverra eu, fringilla eget, purus. Donec tristique pretium sem.
+  
+<h2>Shortcodes</h2>
+
+<h3>Video (With fallback)</h3>
+[video src="source.mp4"]
+[video mp4="source.mp4" ogv="source.ogv"]
+
+<h3>Audio (with fallback)</h3>
+[audio src="source.mp3"]
+[audio ogg="source.ogg" wav="source.wav" mp3="source.mp3"]
+
+<h3>Captions</h3>        
+[caption id="attachment_1" align="alignright" width="150"]<a href="#"><img class="wp-image-1" alt="Sample Image" src="foo.jpg" width="150" height="150" /></a> FooBar Caption[/caption]
+
+        ]]></content:encoded>
       <excerpt:encoded><![CDATA[]]></excerpt:encoded>
       <wp:post_id>4</wp:post_id>
       <wp:post_date>2008-08-02 19:52:26</wp:post_date>


### PR DESCRIPTION
Only supports very basic shortcodes: `[audio]`, `[video]` and `[caption]`
