### PR TITLE
Fixed silent failure when no post_date_gmt was present in "post" item

### DIFF
--- a/lib/wp2ghost.js
+++ b/lib/wp2ghost.js
@@ -119,10 +119,18 @@ exports.fromStream = function(stream) {
 
       var date;
 
+      date = item['wp:post_date_gmt'];
+      if (date == null) {
+          date = item['wp:post_date'];
+        if (date == null) {
+          date='0000-00-00 00:00:00'
+        }
+      }
+
       if (item['wp:post_date_gmt'] !== "0000-00-00 00:00:00") {
-        date = item['wp:post_date_gmt'].match(/(\d{4})-(\d+)-(\d+) (\d+):(\d+):(\d+)/);
+        date = date.match(/(\d{4})-(\d+)-(\d+) (\d+):(\d+):(\d+)/);
       } else {
-        date = item['wp:post_date'].match(/(\d{4})-(\d+)-(\d+) (\d+):(\d+):(\d+)/);
+        date = date.match(/(\d{4})-(\d+)-(\d+) (\d+):(\d+):(\d+)/);
       }
 
       date = date.map(function(e) { return parseInt(e, 10); });

--- a/lib/wp2ghost.js
+++ b/lib/wp2ghost.js
@@ -123,7 +123,7 @@ exports.fromStream = function(stream) {
       if (date == undefined || date == "0000-00-00 00:00:00") {
           date = item['wp:post_date'];
           if (date == undefined) {
-            date='0000-00-00 00:00:00'
+            date='1970-01-01 00:00:00'
           }
       }
 

--- a/lib/wp2ghost.js
+++ b/lib/wp2ghost.js
@@ -117,22 +117,17 @@ exports.fromStream = function(stream) {
     xml.on('endElement: item', function(item) {
       if (item['wp:post_type'] != "post" && item['wp:post_type'] != "page") return;
 
-      var date;
-
-      date = item['wp:post_date_gmt'];
-      if (date == null) {
+      // if post_date_gmt is undefined or 0000 then we check post_date in hope of finding a better date.
+      // if post_date is undefined we dont know the time an assume 0000
+      var date = item['wp:post_date_gmt'];
+      if (date == undefined || date == "0000-00-00 00:00:00") {
           date = item['wp:post_date'];
-        if (date == null) {
-          date='0000-00-00 00:00:00'
-        }
+          if (date == undefined) {
+            date='0000-00-00 00:00:00'
+          }
       }
 
-      if (item['wp:post_date_gmt'] !== "0000-00-00 00:00:00") {
-        date = date.match(/(\d{4})-(\d+)-(\d+) (\d+):(\d+):(\d+)/);
-      } else {
-        date = date.match(/(\d{4})-(\d+)-(\d+) (\d+):(\d+):(\d+)/);
-      }
-
+      date = date.match(/(\d{4})-(\d+)-(\d+) (\d+):(\d+):(\d+)/);
       date = date.map(function(e) { return parseInt(e, 10); });
       var d = new Date(Date.UTC(date[1], date[2]-1, date[3], date[4], date[5], date[6], 0));
 

--- a/test/post.js
+++ b/test/post.js
@@ -10,7 +10,7 @@ before(function(done) {
 	g = data.data;
 	p = g.posts[0];
 	post_missing_both_post_fields = g.posts[1];
-	post_missing_both_post_date_gmt = g.posts[2];
+	post_missing_post_date_gmt = g.posts[2];
 	done();
     },
             function(err)  { done(new Error(err)); });
@@ -36,7 +36,7 @@ describe('Posts', function(){
   });
   describe('post without post_date_gmt', function(){
     it("should exist", function() {
-      if (!post_missing_both_post_date_gmt)
+      if (!post_missing_post_date_gmt)
         throw new Exception();
     });
   });
@@ -90,13 +90,17 @@ describe('Posts', function(){
 
   describe('Post date fallbacks', function(){
     describe('no post_date_gmt or post_date', function(){
-      it("should return a default year 0000-00-00 00:00:00 BC", function() {
-        post_missing_both_post_fields.created_at.should.equal(-2211753600000);
+      it("should return a default year 1970-01-01 00:00:00 AC", function() {
+        var date = new Date("1970-01-01 00:00:00 UTC");
+        var unixtime = date.getTime()
+        post_missing_both_post_fields.created_at.should.equal(unixtime);
       });
     });
     describe('no post_date_gmt', function(){
       it("should fallback to post_date", function() {
-          post_missing_both_post_date_gmt.created_at.should.equal(1303116069000);
+        var date = new Date("2011-04-18 08:41:09 UTC");
+        var unixtime = date.getTime()
+        post_missing_post_date_gmt.created_at.should.equal(unixtime);
       });
     });
   });

--- a/test/post.js
+++ b/test/post.js
@@ -6,7 +6,13 @@ var g;
 var p;
 
 before(function(done) {
-  when.then(function(data) { g = data.data; p = g.posts[0]; done(); },
+    when.then(function(data) {
+	g = data.data;
+	p = g.posts[0];
+	post_missing_both_post_fields = g.posts[1];
+	post_missing_both_post_date_gmt = g.posts[2];
+	done();
+    },
             function(err)  { done(new Error(err)); });
 });
 
@@ -16,11 +22,22 @@ describe('Wordpress XML', function() {
   });
 });
 
-describe('Post', function(){
-  describe('itself', function(){
+describe('Posts', function(){
+  describe('simple post with text', function(){
     it("should exist", function() {
-      p = g.posts[0];
       if (!p) throw new Exception();
+    });
+  });
+  describe('post without both date fields', function(){
+    it("should exist", function() {
+      if (!post_missing_both_post_fields)
+        throw new Exception();
+    });
+  });
+  describe('post without post_date_gmt', function(){
+    it("should exist", function() {
+      if (!post_missing_both_post_date_gmt)
+        throw new Exception();
     });
   });
 
@@ -68,6 +85,19 @@ describe('Post', function(){
   describe('publication date', function(){
     it("should be preserved", function() {
       p.published_at.should.equal(1217724746000);
+    });
+  });
+
+  describe('Post date fallbacks', function(){
+    describe('no post_date_gmt or post_date', function(){
+      it("should return a default year 0000-00-00 00:00:00 BC", function() {
+        post_missing_both_post_fields.created_at.should.equal(-2211753600000);
+      });
+    });
+    describe('no post_date_gmt', function(){
+      it("should fallback to post_date", function() {
+          post_missing_both_post_date_gmt.created_at.should.equal(1303116069000);
+      });
     });
   });
 

--- a/test/wordpress-export.xml
+++ b/test/wordpress-export.xml
@@ -118,7 +118,7 @@ It has multiple lines, some <code>code</code>, and a bit more text.]]></wp:comme
     </item>
 
   <item>
-    <!-- An post missing both post_date_gmt and post_date -->
+    <!-- A post missing both post_date_gmt and post_date -->
     <pubDate>Mon, 18 Apr 2011 08:41:09 +0000</pubDate>
     <content:encoded>stuff</content:encoded>
     <wp:post_type>post</wp:post_type>
@@ -126,7 +126,7 @@ It has multiple lines, some <code>code</code>, and a bit more text.]]></wp:comme
   </item>
 
   <item>
-    <!-- An post missing post_date_gmt but post_date is present -->
+    <!-- A post missing post_date_gmt but post_date is present -->
     <pubDate>Mon, 18 Apr 2011 08:41:09 +0000</pubDate>
     <content:encoded>stuff</content:encoded>
     <wp:post_date>2011-04-18 08:41:09</wp:post_date>

--- a/test/wordpress-export.xml
+++ b/test/wordpress-export.xml
@@ -116,5 +116,23 @@ It has multiple lines, some <code>code</code>, and a bit more text.]]></wp:comme
         <wp:comment_user_id>0</wp:comment_user_id>
       </wp:comment>
     </item>
+
+  <item>
+    <!-- An post missing both post_date_gmt and post_date -->
+    <pubDate>Mon, 18 Apr 2011 08:41:09 +0000</pubDate>
+    <content:encoded>stuff</content:encoded>
+    <wp:post_type>post</wp:post_type>
+    <wp:post_id>1</wp:post_id>
+  </item>
+
+  <item>
+    <!-- An post missing post_date_gmt but post_date is present -->
+    <pubDate>Mon, 18 Apr 2011 08:41:09 +0000</pubDate>
+    <content:encoded>stuff</content:encoded>
+    <wp:post_date>2011-04-18 08:41:09</wp:post_date>
+    <wp:post_type>post</wp:post_type>
+    <wp:post_id>1</wp:post_id>
+  </item>
+
   </channel>
 </rss>


### PR DESCRIPTION
When trying to convert my wordpres .xml I at first got a silent failure. No output was produced nor were any warnings displayed.

The problem and fix can be tested on the following input .xml example. 
Without the fix nothing happens when running:
`node bin/wp2ghost.js wordpress.xml` 

wordpress.xml:

```
<?xml version="1.0" encoding="UTF-8" ?>
<channel>
  <item>
    <pubDate>Mon, 18 Apr 2011 08:41:09 +0000</pubDate>
    <content:encoded>stuff</content:encoded>
    <wp:post_type>post</wp:post_type>
    <wp:post_id>1</wp:post_id>
  </item>
</channel>
```

With this fix the output is

```
{"meta":{"exported_on":1303116069000000,"version":"000"},"data":{"posts":[{"id":4,"title":"Untitled post","slug":"untitled-post","markdown":"stuff>","html":"stuff>","image":null,"featured":false,"page":0,"status":"draft","language":"en_US","meta_title":null,"meta_description":null,"created_at":1303116069000,"created_by":1,"updated_at":1303116069000,"updated_by":1,"published_at":1303116069000,"published_by":1}],"tags":[],"posts_tags":[]}}
```

which can successfully be imported into ghost.

I did assume that if post_date_gmt and post_date were missing we were out of luck. However we usually have a pubDate field as well which can be parsed as well. But in my case where the post_data_gmt and post_date were missing the pubDates were in a weird format seen below:
`<pubDate>Fri, 24146140482 15:36:27 +0000</pubDate>`
So the code would be even better if it were made to try to get the date from pubDate when possible. But I did not need that since this only happened for drafts and I did not personally care about correct dates for them since they will get a proper date once posted anyway.

I got the original wordpress.xml from when i used the export function on a squarespace trial account. It should not make a difference, but just in case Im leaving that tidbit here at the end in case someone else has problems and is searching for an answer.
