### PR TITLE
Use env instead vs hard coded node path in hashbang

### DIFF
--- a/bin/wp2ghost.js
+++ b/bin/wp2ghost.js
@@ -1,4 +1,4 @@
-#!/usr/bin/node
+#!/usr/bin/env node
 var wp2ghost = require('../lib/wp2ghost.js');
 var path = require('path');
 


### PR DESCRIPTION
I use NVM. Had a `node not found` error. It's better to use `#!/usr/bin/env node` in CLI tools to be unopinionated about where node may be installed. Hope this helps :)