### PR TITLE
Collecting the content from custom fields (wp:postmeta -> article_content)

### DIFF
--- a/lib/wp2ghost.js
+++ b/lib/wp2ghost.js
@@ -114,6 +114,7 @@ exports.fromStream = function(stream) {
     var slugs = {};
     xml.collect('category');
     xml.preserve('content:encoded', true);
+    xml.collect('wp:postmeta');
     xml.on('endElement: item', function(item) {
       if (item['wp:post_type'] != "post" && item['wp:post_type'] != "page") return;
 
@@ -157,7 +158,13 @@ exports.fromStream = function(stream) {
         "published_at": pubDate.getTime(),
         "published_by": 1
       };
-
+      if (item['wp:postmeta']) {
+          var content = item['wp:postmeta'].find(element => element['wp:meta_key'] == 'article_content');
+          if ( content && content['wp:meta_value']) {
+              if (post.markdown.length == 0) post.markdown = content['wp:meta_value'];
+              if (post.html.length == 0) post.html = content['wp:meta_value'];
+          }
+      }
       if (!post.title) {
         post.title = 'Untitled post';
       }


### PR DESCRIPTION
This fix should fill the post.html from the 'article_content' if WP has the custom fields and all content is stored in postmeta. 